### PR TITLE
修复家园副标题缺失

### DIFF
--- a/sites/家园.json
+++ b/sites/家园.json
@@ -1,7 +1,7 @@
 {
 	"id": "pthome",
 	"name": "\u94C2\u91D1\u5BB6",
-	"domain": "https://www.pthome.net/",
+	"domain": "https://pthome.net/",
 	"encoding": "UTF-8",
 	"public": false,
 	"search": {
@@ -21,24 +21,24 @@
 		"movie": [{
 			"id": 401,
 			"cat": "Movies",
-			"desc": "Movies/\u7535\u5F71"
+			"desc": "Movies(\u7535\u5F71)"
 		}],
 		"tv": [{
 			"id": 404,
 			"cat": "TV/Documentary",
-			"desc": "Documentaries/\u7EAA\u5F55\u7247"
+			"desc": "Documentaries(\u8BB0\u5F55\u7247)"
 		}, {
 			"id": 405,
 			"cat": "TV/Anime",
-			"desc": "Animations/\u52A8\u6F2B"
+			"desc": "Animations(\u52A8\u6F2B)"
 		}, {
 			"id": 402,
 			"cat": "TV",
-			"desc": "TV Series/\u8FDE\u7EED\u5267"
+			"desc": "TV Series(\u7535\u89C6\u5267)"
 		}, {
 			"id": 403,
-			"cat": "TV",
-			"desc": "TV Shows/\u7EFC\u827A"
+			"cat": "TV/Other",
+			"desc": "TV Shows(\u7EFC\u827A)"
 		}]
 	},
 	"torrents": {
@@ -77,32 +77,28 @@
 				"selector": "a[href*=\"details.php?id=\"]",
 				"attribute": "href"
 			},
-			"poster": {
-				"selector": "img[data-orig]",
-				"attribute": "data-orig"
-			},
 			"download": {
 				"selector": "a[href*=\"download.php?id=\"]",
 				"attribute": "href"
 			},
 			"size": {
-				"selector": "td.rowfollow:nth-child(5)"
+				"selector": "td:nth-child(5)"
 			},
 			"grabs": {
-				"selector": "td.rowfollow:nth-child(8)"
+				"selector": "td:nth-child(8)"
 			},
 			"seeders": {
-				"selector": "td.rowfollow:nth-child(6)"
+				"selector": "td:nth-child(6)"
 			},
 			"leechers": {
-				"selector": "td.rowfollow:nth-child(7)"
+				"selector": "td:nth-child(7)"
 			},
 			"date_elapsed": {
-				"selector": "td.rowfollow:nth-child(4) > span",
+				"selector": "td:nth-child(4) > span",
 				"optional": true
 			},
 			"date_added": {
-				"selector": "td.rowfollow:nth-child(4) > span",
+				"selector": "td:nth-child(4) > span",
 				"attribute": "title",
 				"optional": true
 			},
@@ -134,30 +130,23 @@
 			"free_deadline": {
 				"default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
 				"default_value_format": "%Y-%m-%d %H:%M:%S.%f",
-				"selector": "div > b > span[title]",
+				"selector": "td[class=\"embedded\"] > b > span[title]",
 				"attribute": "title",
 				"filters": [{
 					"name": "dateparse",
 					"args": "%Y-%m-%d %H:%M:%S"
 				}]
 			},
-			"tags": {
-				"selector": "div > a.torrents-tag"
-			},
-			"subject": {
-				"selector": "td.embedded:nth-child(2) > div > div:nth-child(2) > span",
-				"contents": -1
-			},
 			"description": {
-				"selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1)",
-				"remove": "span,a,img,font,b",
-				"contents": -1
+				"selector": "table.torrentname > tr > td.embedded > span[style]",
+				"index": -1
 			},
 			"labels": {
-				"selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1) > span"
+				"selector": "table.torrentname > tr > td.embedded > span.tags"
 			}
 		}
-	},
+	}
+},
 	"price": {
 		"FREE": ["//h1[@id='top']/b/font[@class='free']"],
 		"2XFREE": ["//h1[@id='top']/b/font[@class='twoupfree']"],

--- a/sites/家园.json
+++ b/sites/家园.json
@@ -1,7 +1,7 @@
 {
-    "id": "jiayuan",
-    "name": "\u5bb6\u56ed",
-    "domain": "https://hdhome.org/",
+    "id": "pthome",
+    "name": "铂金家",
+    "domain": "https://www.pthome.net/",
     "encoding": "UTF-8",
     "public": false,
     "search": {
@@ -22,226 +22,31 @@
     "category": {
         "movie": [
             {
-                "id": 411,
-                "cat": "Movies/SD",
-                "desc": "Movies SD"
-            },
-            {
-                "id": 412,
-                "cat": "Movies/SD",
-                "desc": "Movies IPad"
-            },
-            {
-                "id": 413,
-                "cat": "Movies/HD",
-                "desc": "Movies 720p"
-            },
-            {
-                "id": 414,
-                "cat": "Movies/HD",
-                "desc": "Movies 1080p"
-            },
-            {
-                "id": 415,
-                "cat": "Movies/HD",
-                "desc": "Movies REMUX"
-            },
-            {
-                "id": 450,
-                "cat": "Movies/BluRay",
-                "desc": "Movies Bluray"
-            },
-            {
-                "id": 499,
-                "cat": "Movies/BluRay",
-                "desc": "Movies UHD Blu-ray"
-            },
-            {
-                "id": 416,
-                "cat": "Movies/UHD",
-                "desc": "Movies 2160p"
+                "id": 401,
+                "cat": "Movies",
+                "desc": "Movies/电影"
             }
         ],
         "tv": [
             {
-                "id": 417,
+                "id": 404,
                 "cat": "TV/Documentary",
-                "desc": "Doc SD"
+                "desc": "Documentaries/纪录片"
             },
             {
-                "id": 418,
-                "cat": "TV/Documentary",
-                "desc": "Doc IPad"
-            },
-            {
-                "id": 419,
-                "cat": "TV/Documentary",
-                "desc": "Doc 720p"
-            },
-            {
-                "id": 420,
-                "cat": "TV/Documentary",
-                "desc": "Doc 1080p"
-            },
-            {
-                "id": 421,
-                "cat": "TV/Documentary",
-                "desc": "Doc REMUX"
-            },
-            {
-                "id": 451,
-                "cat": "TV/Documentary",
-                "desc": "Doc Bluray"
-            },
-            {
-                "id": 500,
-                "cat": "TV/Documentary",
-                "desc": "Doc UHD Blu-ray"
-            },
-            {
-                "id": 422,
-                "cat": "TV/Documentary",
-                "desc": "Doc 2160p"
-            },
-            {
-                "id": 423,
-                "cat": "TV/HD",
-                "desc": "TVMusic 720p"
-            },
-            {
-                "id": 424,
-                "cat": "TV/HD",
-                "desc": "TVMusic 1080i"
-            },
-            {
-                "id": 425,
-                "cat": "TV/SD",
-                "desc": "TVShow SD"
-            },
-            {
-                "id": 426,
-                "cat": "TV/SD",
-                "desc": "TVShow IPad"
-            },
-            {
-                "id": 471,
-                "cat": "TV/SD",
-                "desc": "TVShow IPad"
-            },
-            {
-                "id": 427,
-                "cat": "TV/HD",
-                "desc": "TVShow 720p"
-            },
-            {
-                "id": 428,
-                "cat": "TV/HD",
-                "desc": "TVShow 1080i"
-            },
-            {
-                "id": 429,
-                "cat": "TV/HD",
-                "desc": "TVShow 1080p"
-            },
-            {
-                "id": 430,
-                "cat": "TV/HD",
-                "desc": "TVShow REMUX"
-            },
-            {
-                "id": 452,
-                "cat": "TV/HD",
-                "desc": "TVShows Bluray"
-            },
-            {
-                "id": 431,
-                "cat": "TV/HD",
-                "desc": "TVShow 2160p"
-            },
-            {
-                "id": 432,
-                "cat": "TV/SD",
-                "desc": "TVSeries SD"
-            },
-            {
-                "id": 433,
-                "cat": "TV/SD",
-                "desc": "TVSeries IPad"
-            },
-            {
-                "id": 434,
-                "cat": "TV/HD",
-                "desc": "TVSeries 720p"
-            },
-            {
-                "id": 435,
-                "cat": "TV/HD",
-                "desc": "TVSeries 1080i"
-            },
-            {
-                "id": 436,
-                "cat": "TV/HD",
-                "desc": "TVSeries 1080p"
-            },
-            {
-                "id": 437,
-                "cat": "TV/HD",
-                "desc": "TVSeries REMUX"
-            },
-            {
-                "id": 453,
-                "cat": "TV/HD",
-                "desc": "TVSereis Bluray"
-            },
-            {
-                "id": 438,
-                "cat": "TV/UHD",
-                "desc": "TVSeries 2160p"
-            },
-            {
-                "id": 502,
-                "cat": "TV/UHD",
-                "desc": "TVSeries 4K Bluray"
-            },
-            {
-                "id": 444,
+                "id": 405,
                 "cat": "TV/Anime",
-                "desc": "Anime SD"
+                "desc": "Animations/动漫"
             },
             {
-                "id": 445,
-                "cat": "TV/Anime",
-                "desc": "Anime IPad"
+                "id": 402,
+                "cat": "TV",
+                "desc": "TV Series/连续剧"
             },
             {
-                "id": 446,
-                "cat": "TV/Anime",
-                "desc": "Anime 720p"
-            },
-            {
-                "id": 447,
-                "cat": "TV/Anime",
-                "desc": "Anime 1080p"
-            },
-            {
-                "id": 448,
-                "cat": "TV/Anime",
-                "desc": "Anime REMUX"
-            },
-            {
-                "id": 454,
-                "cat": "TV/Anime",
-                "desc": "Anime Bluray"
-            },
-            {
-                "id": 449,
-                "cat": "TV/Anime",
-                "desc": "Anime 2160p"
-            },
-            {
-                "id": 501,
-                "cat": "TV/Anime",
-                "desc": "Anime UHD Blu-ray"
+                "id": 403,
+                "cat": "TV",
+                "desc": "TV Shows/综艺"
             }
         ]
     },
@@ -263,6 +68,16 @@
                     }
                 ]
             },
+            "category": {
+                "selector": "a[href*=\"?cat=\"]",
+                "attribute": "href",
+                "filters": [
+                    {
+                        "name": "querystring",
+                        "args": "cat"
+                    }
+                ]
+            },
             "title_default": {
                 "selector": "a[href*=\"details.php?id=\"]"
             },
@@ -274,50 +89,36 @@
             "title": {
                 "text": "{% if fields['title_optional'] %}{{ fields['title_optional'] }}{% else %}{{ fields['title_default'] }}{% endif %}"
             },
-            "category": {
-                "selector": "a[href*=\"?cat=\"]",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "replace",
-                        "args": [
-                            "?",
-                            ""
-                        ]
-                    },
-                    {
-                        "name": "querystring",
-                        "args": "cat"
-                    }
-                ]
-            },
             "details": {
                 "selector": "a[href*=\"details.php?id=\"]",
                 "attribute": "href"
+            },
+            "poster": {
+                "selector": "img[data-orig]",
+                "attribute": "data-orig"
             },
             "download": {
                 "selector": "a[href*=\"download.php?id=\"]",
                 "attribute": "href"
             },
-            "imdbid": {
-                "selector": "div.imdb_100 > a",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "re_search",
-                        "args": [
-                            "tt\\d+",
-                            0
-                        ]
-                    }
-                ]
+            "size": {
+                "selector": "td.rowfollow:nth-child(5)"
+            },
+            "grabs": {
+                "selector": "td.rowfollow:nth-child(8)"
+            },
+            "seeders": {
+                "selector": "td.rowfollow:nth-child(6)"
+            },
+            "leechers": {
+                "selector": "td.rowfollow:nth-child(7)"
             },
             "date_elapsed": {
-                "selector": "td:nth-child(4) > span",
+                "selector": "td.rowfollow:nth-child(4) > span",
                 "optional": true
             },
             "date_added": {
-                "selector": "td:nth-child(4) > span",
+                "selector": "td.rowfollow:nth-child(4) > span",
                 "attribute": "title",
                 "optional": true
             },
@@ -329,18 +130,6 @@
                         "args": "%Y-%m-%d %H:%M:%S"
                     }
                 ]
-            },
-            "size": {
-                "selector": "td:nth-child(5)"
-            },
-            "seeders": {
-                "selector": "td:nth-child(6)"
-            },
-            "leechers": {
-                "selector": "td:nth-child(7)"
-            },
-            "grabs": {
-                "selector": "td:nth-child(8)"
             },
             "downloadvolumefactor": {
                 "case": {
@@ -363,41 +152,45 @@
             "free_deadline": {
                 "default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
                 "default_value_format": "%Y-%m-%d %H:%M:%S.%f",
-                "selector": "img.pro_free,img.pro_free2up",
-                "attribute": "onmouseover",
+                "selector": "div > b > span[title]",
+                "attribute": "title",
                 "filters": [
-                    {
-                        "name": "re_search",
-                        "args": [
-                            "\\d+-\\d+-\\d+ \\d+:\\d+:\\d+",
-                            0
-                        ]
-                    },
                     {
                         "name": "dateparse",
                         "args": "%Y-%m-%d %H:%M:%S"
                     }
                 ]
             },
+            "tags": {
+                "selector": "div > a.torrents-tag"
+            },
+            "subject": {
+                "selector": "td.embedded:nth-child(2) > div > div:nth-child(2) > span",
+                "contents": -1
+            },
             "description": {
-                "selector": "td:nth-child(2) > table > tr > td.embedded > span[style]",
+                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1)",
+                "remove": "span,a,img,font,b",
                 "contents": -1
             },
             "labels": {
-                "selector": "td:nth-child(2) > table > tr > td.embedded > span.tags"
+                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1) > span"
             }
         }
     },
-    "conf": {
+    "price": {
         "FREE": [
             "//h1[@id='top']/b/font[@class='free']"
         ],
         "2XFREE": [
             "//h1[@id='top']/b/font[@class='twoupfree']"
         ],
-        "HR": [],
+        "HR": [
+            "//h1[@id='top']/img[@class='hitandrun']"
+        ],
         "PEER_COUNT": [
             "//div[@id='peercount']/b[1]"
         ]
-    }
+    },
+    "system_type": "nexus_php"
 }

--- a/sites/家园.json
+++ b/sites/家园.json
@@ -1,196 +1,168 @@
 {
-    "id": "pthome",
-    "name": "铂金家",
-    "domain": "https://www.pthome.net/",
-    "encoding": "UTF-8",
-    "public": false,
-    "search": {
-        "paths": [
-            {
-                "path": "torrents.php",
-                "method": "get"
-            }
-        ],
-        "params": {
-            "search": "{keyword}"
-        },
-        "batch": {
-            "delimiter": " ",
-            "space_replace": "_"
-        }
-    },
-    "category": {
-        "movie": [
-            {
-                "id": 401,
-                "cat": "Movies",
-                "desc": "Movies/电影"
-            }
-        ],
-        "tv": [
-            {
-                "id": 404,
-                "cat": "TV/Documentary",
-                "desc": "Documentaries/纪录片"
-            },
-            {
-                "id": 405,
-                "cat": "TV/Anime",
-                "desc": "Animations/动漫"
-            },
-            {
-                "id": 402,
-                "cat": "TV",
-                "desc": "TV Series/连续剧"
-            },
-            {
-                "id": 403,
-                "cat": "TV",
-                "desc": "TV Shows/综艺"
-            }
-        ]
-    },
-    "torrents": {
-        "list": {
-            "selector": "table.torrents > tr:has(\"table.torrentname\")"
-        },
-        "fields": {
-            "id": {
-                "selector": "a[href*=\"details.php?id=\"]",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "re_search",
-                        "args": [
-                            "\\d+",
-                            0
-                        ]
-                    }
-                ]
-            },
-            "category": {
-                "selector": "a[href*=\"?cat=\"]",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "querystring",
-                        "args": "cat"
-                    }
-                ]
-            },
-            "title_default": {
-                "selector": "a[href*=\"details.php?id=\"]"
-            },
-            "title_optional": {
-                "optional": true,
-                "selector": "a[title][href*=\"details.php?id=\"]",
-                "attribute": "title"
-            },
-            "title": {
-                "text": "{% if fields['title_optional'] %}{{ fields['title_optional'] }}{% else %}{{ fields['title_default'] }}{% endif %}"
-            },
-            "details": {
-                "selector": "a[href*=\"details.php?id=\"]",
-                "attribute": "href"
-            },
-            "poster": {
-                "selector": "img[data-orig]",
-                "attribute": "data-orig"
-            },
-            "download": {
-                "selector": "a[href*=\"download.php?id=\"]",
-                "attribute": "href"
-            },
-            "size": {
-                "selector": "td.rowfollow:nth-child(5)"
-            },
-            "grabs": {
-                "selector": "td.rowfollow:nth-child(8)"
-            },
-            "seeders": {
-                "selector": "td.rowfollow:nth-child(6)"
-            },
-            "leechers": {
-                "selector": "td.rowfollow:nth-child(7)"
-            },
-            "date_elapsed": {
-                "selector": "td.rowfollow:nth-child(4) > span",
-                "optional": true
-            },
-            "date_added": {
-                "selector": "td.rowfollow:nth-child(4) > span",
-                "attribute": "title",
-                "optional": true
-            },
-            "date": {
-                "text": "{% if fields['date_elapsed'] or fields['date_added'] %}{{ fields['date_elapsed'] if fields['date_elapsed'] else fields['date_added'] }}{% else %}now{% endif %}",
-                "filters": [
-                    {
-                        "name": "dateparse",
-                        "args": "%Y-%m-%d %H:%M:%S"
-                    }
-                ]
-            },
-            "downloadvolumefactor": {
-                "case": {
-                    "img.pro_free": 0,
-                    "img.pro_free2up": 0,
-                    "img.pro_50pctdown": 0.5,
-                    "img.pro_50pctdown2up": 0.5,
-                    "img.pro_30pctdown": 0.3,
-                    "*": 1
-                }
-            },
-            "uploadvolumefactor": {
-                "case": {
-                    "img.pro_50pctdown2up": 2,
-                    "img.pro_free2up": 2,
-                    "img.pro_2up": 2,
-                    "*": 1
-                }
-            },
-            "free_deadline": {
-                "default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
-                "default_value_format": "%Y-%m-%d %H:%M:%S.%f",
-                "selector": "div > b > span[title]",
-                "attribute": "title",
-                "filters": [
-                    {
-                        "name": "dateparse",
-                        "args": "%Y-%m-%d %H:%M:%S"
-                    }
-                ]
-            },
-            "tags": {
-                "selector": "div > a.torrents-tag"
-            },
-            "subject": {
-                "selector": "td.embedded:nth-child(2) > div > div:nth-child(2) > span",
-                "contents": -1
-            },
-            "description": {
-                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1)",
-                "remove": "span,a,img,font,b",
-                "contents": -1
-            },
-            "labels": {
-                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1) > span"
-            }
-        }
-    },
-    "price": {
-        "FREE": [
-            "//h1[@id='top']/b/font[@class='free']"
-        ],
-        "2XFREE": [
-            "//h1[@id='top']/b/font[@class='twoupfree']"
-        ],
-        "HR": [
-            "//h1[@id='top']/img[@class='hitandrun']"
-        ],
-        "PEER_COUNT": [
-            "//div[@id='peercount']/b[1]"
-        ]
-    },
-    "system_type": "nexus_php"
+	"id": "pthome",
+	"name": "\u94C2\u91D1\u5BB6",
+	"domain": "https://www.pthome.net/",
+	"encoding": "UTF-8",
+	"public": false,
+	"search": {
+		"paths": [{
+			"path": "torrents.php",
+			"method": "get"
+		}],
+		"params": {
+			"search": "{keyword}"
+		},
+		"batch": {
+			"delimiter": " ",
+			"space_replace": "_"
+		}
+	},
+	"category": {
+		"movie": [{
+			"id": 401,
+			"cat": "Movies",
+			"desc": "Movies/\u7535\u5F71"
+		}],
+		"tv": [{
+			"id": 404,
+			"cat": "TV/Documentary",
+			"desc": "Documentaries/\u7EAA\u5F55\u7247"
+		}, {
+			"id": 405,
+			"cat": "TV/Anime",
+			"desc": "Animations/\u52A8\u6F2B"
+		}, {
+			"id": 402,
+			"cat": "TV",
+			"desc": "TV Series/\u8FDE\u7EED\u5267"
+		}, {
+			"id": 403,
+			"cat": "TV",
+			"desc": "TV Shows/\u7EFC\u827A"
+		}]
+	},
+	"torrents": {
+		"list": {
+			"selector": "table.torrents > tr:has(\"table.torrentname\")"
+		},
+		"fields": {
+			"id": {
+				"selector": "a[href*=\"details.php?id=\"]",
+				"attribute": "href",
+				"filters": [{
+					"name": "re_search",
+					"args": ["\\d+", 0]
+				}]
+			},
+			"category": {
+				"selector": "a[href*=\"?cat=\"]",
+				"attribute": "href",
+				"filters": [{
+					"name": "querystring",
+					"args": "cat"
+				}]
+			},
+			"title_default": {
+				"selector": "a[href*=\"details.php?id=\"]"
+			},
+			"title_optional": {
+				"optional": true,
+				"selector": "a[title][href*=\"details.php?id=\"]",
+				"attribute": "title"
+			},
+			"title": {
+				"text": "{% if fields['title_optional'] %}{{ fields['title_optional'] }}{% else %}{{ fields['title_default'] }}{% endif %}"
+			},
+			"details": {
+				"selector": "a[href*=\"details.php?id=\"]",
+				"attribute": "href"
+			},
+			"poster": {
+				"selector": "img[data-orig]",
+				"attribute": "data-orig"
+			},
+			"download": {
+				"selector": "a[href*=\"download.php?id=\"]",
+				"attribute": "href"
+			},
+			"size": {
+				"selector": "td.rowfollow:nth-child(5)"
+			},
+			"grabs": {
+				"selector": "td.rowfollow:nth-child(8)"
+			},
+			"seeders": {
+				"selector": "td.rowfollow:nth-child(6)"
+			},
+			"leechers": {
+				"selector": "td.rowfollow:nth-child(7)"
+			},
+			"date_elapsed": {
+				"selector": "td.rowfollow:nth-child(4) > span",
+				"optional": true
+			},
+			"date_added": {
+				"selector": "td.rowfollow:nth-child(4) > span",
+				"attribute": "title",
+				"optional": true
+			},
+			"date": {
+				"text": "{% if fields['date_elapsed'] or fields['date_added'] %}{{ fields['date_elapsed'] if fields['date_elapsed'] else fields['date_added'] }}{% else %}now{% endif %}",
+				"filters": [{
+					"name": "dateparse",
+					"args": "%Y-%m-%d %H:%M:%S"
+				}]
+			},
+			"downloadvolumefactor": {
+				"case": {
+					"img.pro_free": 0,
+					"img.pro_free2up": 0,
+					"img.pro_50pctdown": 0.5,
+					"img.pro_50pctdown2up": 0.5,
+					"img.pro_30pctdown": 0.3,
+					"*": 1
+				}
+			},
+			"uploadvolumefactor": {
+				"case": {
+					"img.pro_50pctdown2up": 2,
+					"img.pro_free2up": 2,
+					"img.pro_2up": 2,
+					"*": 1
+				}
+			},
+			"free_deadline": {
+				"default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
+				"default_value_format": "%Y-%m-%d %H:%M:%S.%f",
+				"selector": "div > b > span[title]",
+				"attribute": "title",
+				"filters": [{
+					"name": "dateparse",
+					"args": "%Y-%m-%d %H:%M:%S"
+				}]
+			},
+			"tags": {
+				"selector": "div > a.torrents-tag"
+			},
+			"subject": {
+				"selector": "td.embedded:nth-child(2) > div > div:nth-child(2) > span",
+				"contents": -1
+			},
+			"description": {
+				"selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1)",
+				"remove": "span,a,img,font,b",
+				"contents": -1
+			},
+			"labels": {
+				"selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1) > span"
+			}
+		}
+	},
+	"price": {
+		"FREE": ["//h1[@id='top']/b/font[@class='free']"],
+		"2XFREE": ["//h1[@id='top']/b/font[@class='twoupfree']"],
+		"HR": ["//h1[@id='top']/img[@class='hitandrun']"],
+		"PEER_COUNT": ["//div[@id='peercount']/b[1]"]
+	},
+	"system_type": "nexus_php"
 }

--- a/sites/铂金家.json
+++ b/sites/铂金家.json
@@ -1,6 +1,6 @@
 {
 	"id": "pthome",
-	"name": "\u94C2\u91D1\u5BB6",
+	"name": "\u94c2\u91d1\u5bb6",
 	"domain": "https://pthome.net/",
 	"encoding": "UTF-8",
 	"public": false,
@@ -21,24 +21,24 @@
 		"movie": [{
 			"id": 401,
 			"cat": "Movies",
-			"desc": "Movies(\u7535\u5F71)"
+			"desc": "Movies(\u7535\u5f71)"
 		}],
 		"tv": [{
 			"id": 404,
 			"cat": "TV/Documentary",
-			"desc": "Documentaries(\u8BB0\u5F55\u7247)"
+			"desc": "Documentaries(\u8bb0\u5f55\u7247)"
 		}, {
 			"id": 405,
 			"cat": "TV/Anime",
-			"desc": "Animations(\u52A8\u6F2B)"
+			"desc": "Animations(\u52a8\u6f2b)"
 		}, {
 			"id": 402,
 			"cat": "TV",
-			"desc": "TV Series(\u7535\u89C6\u5267)"
+			"desc": "TV Series(\u7535\u89c6\u5267)"
 		}, {
 			"id": 403,
 			"cat": "TV/Other",
-			"desc": "TV Shows(\u7EFC\u827A)"
+			"desc": "TV Shows(\u7efc\u827a)"
 		}]
 	},
 	"torrents": {

--- a/sites/铂金家.json
+++ b/sites/铂金家.json
@@ -145,8 +145,7 @@
 				"selector": "table.torrentname > tr > td.embedded > span.tags"
 			}
 		}
-	}
-},
+	},
 	"price": {
 		"FREE": ["//h1[@id='top']/b/font[@class='free']"],
 		"2XFREE": ["//h1[@id='top']/b/font[@class='twoupfree']"],


### PR DESCRIPTION
用的3.2.2原版数据，不知道H大在移植的过程中用了什么数据，导致原版3.2.2的一些副标题消失了

![image](https://github.com/hsuyelin/nas-tools-sites/assets/89971817/98985229-9550-462b-a899-d4b6c6e430f6)
![image](https://github.com/hsuyelin/nas-tools-sites/assets/89971817/40c3e6f4-1286-456a-b83a-645e501ab531)
