### PR TITLE
修复PT之家副标题.json

### DIFF
--- a/sites/PT之家.json
+++ b/sites/PT之家.json
@@ -1,195 +1,155 @@
 {
-    "id": "PTHome",
-    "name": "PT\u4e4b\u5bb6",
-    "domain": "https://www.pthome.net/",
-    "encoding": "UTF-8",
-    "public": false,
-    "search": {
-        "paths": [
-            {
-                "path": "torrents.php",
-                "method": "get"
-            }
-        ],
-        "params": {
-            "search": "{keyword}"
-        },
-        "batch": {
-            "delimiter": " ",
-            "space_replace": "_"
-        }
-    },
-    "category": {
-        "movie": [
-            {
-                "id": 401,
-                "cat": "Movies",
-                "desc": "Movies/\u7535\u5f71"
-            }
-        ],
-        "tv": [
-            {
-                "id": 404,
-                "cat": "TV/Documentary",
-                "desc": "Documentaries/\u7eaa\u5f55\u7247"
-            },
-            {
-                "id": 405,
-                "cat": "TV/Anime",
-                "desc": "Animations/\u52a8\u6f2b"
-            },
-            {
-                "id": 402,
-                "cat": "TV",
-                "desc": "TV Series/\u8fde\u7eed\u5267"
-            },
-            {
-                "id": 403,
-                "cat": "TV",
-                "desc": "TV Shows/\u7efc\u827a"
-            }
-        ]
-    },
-    "torrents": {
-        "list": {
-            "selector": "table.torrents > tr:has(\"table.torrentname\")"
-        },
-        "fields": {
-            "id": {
-                "selector": "a[href*=\"details.php?id=\"]",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "re_search",
-                        "args": [
-                            "\\d+",
-                            0
-                        ]
-                    }
-                ]
-            },
-            "category": {
-                "selector": "a[href*=\"?cat=\"]",
-                "attribute": "href",
-                "filters": [
-                    {
-                        "name": "querystring",
-                        "args": "cat"
-                    }
-                ]
-            },
-            "title_default": {
-                "selector": "a[href*=\"details.php?id=\"]"
-            },
-            "title_optional": {
-                "optional": true,
-                "selector": "a[title][href*=\"details.php?id=\"]",
-                "attribute": "title"
-            },
-            "title": {
-                "text": "{% if fields['title_optional'] %}{{ fields['title_optional'] }}{% else %}{{ fields['title_default'] }}{% endif %}"
-            },
-            "details": {
-                "selector": "a[href*=\"details.php?id=\"]",
-                "attribute": "href"
-            },
-            "poster": {
-                "selector": "img[data-orig]",
-                "attribute": "data-orig"
-            },
-            "download": {
-                "selector": "a[href*=\"download.php?id=\"]",
-                "attribute": "href"
-            },
-            "size": {
-                "selector": "td.rowfollow:nth-child(5)"
-            },
-            "grabs": {
-                "selector": "td.rowfollow:nth-child(8)"
-            },
-            "seeders": {
-                "selector": "td.rowfollow:nth-child(6)"
-            },
-            "leechers": {
-                "selector": "td.rowfollow:nth-child(7)"
-            },
-            "date_elapsed": {
-                "selector": "td.rowfollow:nth-child(4) > span",
-                "optional": true
-            },
-            "date_added": {
-                "selector": "td.rowfollow:nth-child(4) > span",
-                "attribute": "title",
-                "optional": true
-            },
-            "date": {
-                "text": "{% if fields['date_elapsed'] or fields['date_added'] %}{{ fields['date_elapsed'] if fields['date_elapsed'] else fields['date_added'] }}{% else %}now{% endif %}",
-                "filters": [
-                    {
-                        "name": "dateparse",
-                        "args": "%Y-%m-%d %H:%M:%S"
-                    }
-                ]
-            },
-            "downloadvolumefactor": {
-                "case": {
-                    "img.pro_free": 0,
-                    "img.pro_free2up": 0,
-                    "img.pro_50pctdown": 0.5,
-                    "img.pro_50pctdown2up": 0.5,
-                    "img.pro_30pctdown": 0.3,
-                    "*": 1
-                }
-            },
-            "uploadvolumefactor": {
-                "case": {
-                    "img.pro_50pctdown2up": 2,
-                    "img.pro_free2up": 2,
-                    "img.pro_2up": 2,
-                    "*": 1
-                }
-            },
-            "free_deadline": {
-                "default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
-                "default_value_format": "%Y-%m-%d %H:%M:%S.%f",
-                "selector": "div > b > span[title]",
-                "attribute": "title",
-                "filters": [
-                    {
-                        "name": "dateparse",
-                        "args": "%Y-%m-%d %H:%M:%S"
-                    }
-                ]
-            },
-            "tags": {
-                "selector": "div > a.torrents-tag"
-            },
-            "subject": {
-                "selector": "td.embedded:nth-child(2) > div > div:nth-child(2) > span",
-                "contents": -1
-            },
-            "description": {
-                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1)",
-                "remove": "span,a,img,font,b",
-                "contents": -1
-            },
-            "labels": {
-                "selector": "td:nth-child(2) > table.torrentname > tr > td:nth-child(1) > span"
-            }
-        }
-    },
-    "conf": {
-        "FREE": [
-            "//h1[@id='top']/b/font[@class='free']"
-        ],
-        "2XFREE": [
-            "//h1[@id='top']/b/font[@class='twoupfree']"
-        ],
-        "HR": [
-            "//h1[@id='top']/img[@class='hitandrun']"
-        ],
-        "PEER_COUNT": [
-            "//div[@id='peercount']/b[1]"
-        ]
-    }
+	"id": "pthome",
+	"name": "\u94c2\u91d1\u5bb6",
+	"domain": "https://pthome.net/",
+	"encoding": "UTF-8",
+	"public": false,
+	"search": {
+		"paths": [{
+			"path": "torrents.php",
+			"method": "get"
+		}],
+		"params": {
+			"search": "{keyword}"
+		},
+		"batch": {
+			"delimiter": " ",
+			"space_replace": "_"
+		}
+	},
+	"category": {
+		"movie": [{
+			"id": 401,
+			"cat": "Movies",
+			"desc": "Movies(\u7535\u5f71)"
+		}],
+		"tv": [{
+			"id": 404,
+			"cat": "TV/Documentary",
+			"desc": "Documentaries(\u8bb0\u5f55\u7247)"
+		}, {
+			"id": 405,
+			"cat": "TV/Anime",
+			"desc": "Animations(\u52a8\u6f2b)"
+		}, {
+			"id": 402,
+			"cat": "TV",
+			"desc": "TV Series(\u7535\u89c6\u5267)"
+		}, {
+			"id": 403,
+			"cat": "TV/Other",
+			"desc": "TV Shows(\u7efc\u827a)"
+		}]
+	},
+	"torrents": {
+		"list": {
+			"selector": "table.torrents > tr:has(\"table.torrentname\")"
+		},
+		"fields": {
+			"id": {
+				"selector": "a[href*=\"details.php?id=\"]",
+				"attribute": "href",
+				"filters": [{
+					"name": "re_search",
+					"args": ["\\d+", 0]
+				}]
+			},
+			"category": {
+				"selector": "a[href*=\"?cat=\"]",
+				"attribute": "href",
+				"filters": [{
+					"name": "querystring",
+					"args": "cat"
+				}]
+			},
+			"title_default": {
+				"selector": "a[href*=\"details.php?id=\"]"
+			},
+			"title_optional": {
+				"optional": true,
+				"selector": "a[title][href*=\"details.php?id=\"]",
+				"attribute": "title"
+			},
+			"title": {
+				"text": "{% if fields['title_optional'] %}{{ fields['title_optional'] }}{% else %}{{ fields['title_default'] }}{% endif %}"
+			},
+			"details": {
+				"selector": "a[href*=\"details.php?id=\"]",
+				"attribute": "href"
+			},
+			"download": {
+				"selector": "a[href*=\"download.php?id=\"]",
+				"attribute": "href"
+			},
+			"size": {
+				"selector": "td:nth-child(5)"
+			},
+			"grabs": {
+				"selector": "td:nth-child(8)"
+			},
+			"seeders": {
+				"selector": "td:nth-child(6)"
+			},
+			"leechers": {
+				"selector": "td:nth-child(7)"
+			},
+			"date_elapsed": {
+				"selector": "td:nth-child(4) > span",
+				"optional": true
+			},
+			"date_added": {
+				"selector": "td:nth-child(4) > span",
+				"attribute": "title",
+				"optional": true
+			},
+			"date": {
+				"text": "{% if fields['date_elapsed'] or fields['date_added'] %}{{ fields['date_elapsed'] if fields['date_elapsed'] else fields['date_added'] }}{% else %}now{% endif %}",
+				"filters": [{
+					"name": "dateparse",
+					"args": "%Y-%m-%d %H:%M:%S"
+				}]
+			},
+			"downloadvolumefactor": {
+				"case": {
+					"img.pro_free": 0,
+					"img.pro_free2up": 0,
+					"img.pro_50pctdown": 0.5,
+					"img.pro_50pctdown2up": 0.5,
+					"img.pro_30pctdown": 0.3,
+					"*": 1
+				}
+			},
+			"uploadvolumefactor": {
+				"case": {
+					"img.pro_50pctdown2up": 2,
+					"img.pro_free2up": 2,
+					"img.pro_2up": 2,
+					"*": 1
+				}
+			},
+			"free_deadline": {
+				"default_value": "{% if fields['downloadvolumefactor']==0 %}{{max_time}}{% endif%}",
+				"default_value_format": "%Y-%m-%d %H:%M:%S.%f",
+				"selector": "td[class=\"embedded\"] > b > span[title]",
+				"attribute": "title",
+				"filters": [{
+					"name": "dateparse",
+					"args": "%Y-%m-%d %H:%M:%S"
+				}]
+			},
+			"description": {
+				"selector": "table.torrentname > tr > td.embedded > span[style]",
+				"index": -1
+			},
+			"labels": {
+				"selector": "table.torrentname > tr > td.embedded > span.tags"
+			}
+		}
+	},
+	"conf": {
+		"FREE": ["//h1[@id='top']/b/font[@class='free']"],
+		"2XFREE": ["//h1[@id='top']/b/font[@class='twoupfree']"],
+		"HR": ["//h1[@id='top']/img[@class='hitandrun']"],
+		"PEER_COUNT": ["//div[@id='peercount']/b[1]"]
+	}
 }


### PR DESCRIPTION
用的3.2.2原版数据，不知道H大在移植的过程中用了什么数据，导致原版3.2.2的一些副标题消失了

![image](https://github.com/hsuyelin/nas-tools-sites/assets/89971817/98985229-9550-462b-a899-d4b6c6e430f6)
![image](https://github.com/hsuyelin/nas-tools-sites/assets/89971817/40c3e6f4-1286-456a-b83a-645e501ab531)


之前的搞错了。这次对了